### PR TITLE
S3 Cross Account Replication Walthrough 3: add missing destination AccountId in json example

### DIFF
--- a/doc_source/crr-walkthrough-3.md
+++ b/doc_source/crr-walkthrough-3.md
@@ -38,6 +38,7 @@ In this exercise, you update replication configuration in exercise 2 \([Walkthro
            "Prefix": "Tax",
            "Status": "Enabled",
            "Destination": {
+             "Account": "AWS-ID-Account-B",
              "Bucket": "arn:aws:s3:::destination-bucket",
              "AccessControlTranslation" : {
      		   "Owner" : "Destination"


### PR DESCRIPTION
*Description of changes:*
When following the walkthrough I noticed the json example for replication configuration rule is not updated with account id as the xml above, this pull request should fix it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
