### PR TITLE
Add clarification arround quoting for s3 access log format

### DIFF
--- a/doc_source/LogFormat.md
+++ b/doc_source/LogFormat.md
@@ -12,7 +12,7 @@ The server access log files consist of a sequence of new\-line delimited log rec
 ```
 
 **Note**  
-Any field can be set to `-` to indicate that the data was unknown or unavailable, or that the field was not applicable to this request\. 
+Any field can be set to `-` or `"-"` to indicate that the data was unknown or unavailable, or that the field was not applicable to this request\. 
 
 The following list describes the log record fields\.
 


### PR DESCRIPTION
*Description of changes:*
Added minor edit to make clear around the nill field for s3 server access logs. 
The nill `-` in s3 server access logs can actually optionally be `-` or `"-"`.
And not accounting for the optional quotes can break log parsing.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
