### PR TITLE
adding a mention about the format of the times in the request being in UTC

### DIFF
--- a/doc_source/LogFormat.md
+++ b/doc_source/LogFormat.md
@@ -33,7 +33,7 @@ mybucket
 ```
 
 **Time**  
-The time at which the request was received\. The format, using `strftime()` terminology, is as follows: `[%d/%b/%Y:%H:%M:%S %z]`  
+The time at which the request was received; these dates and times are in Coordinated Universal time (UTC)\. The format, using `strftime()` terminology, is as follows: `[%d/%b/%Y:%H:%M:%S %z]`  
 **Example Entry**  
 
 ```


### PR DESCRIPTION
adding a mention about the format of the times in the request being in UTC

*Issue #, if available:*
no timezone is specified about the times logged in the request

*Description of changes:*
adding a mention about the format of the times in the request being in UTC


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
