### PR TITLE
doc is out of date, IAM users / roles from other accounts can remove …

### DIFF
--- a/doc_source/DeleteMarker.md
+++ b/doc_source/DeleteMarker.md
@@ -6,7 +6,7 @@ A delete marker has a key name \(or key\) and version ID like any other object\.
 + It does not have data associated with it\.
 + It is not associated with an access control list \(ACL\) value\.
 + It does not retrieve anything from a `GET` request because it has no data; you get a 404 error\.
-+ The only operation you can use on a delete marker is `DELETE`, and only the bucket owner can issue such a request\.
++ "The only operation you can make against a delete marker is an S3 API DELETE call, in order to do this you will need an IAM user/role with the appropriate access or the root account to issue such a request." \.
 
 Delete markers accrue a nominal charge for storage in Amazon S3\. The storage size of a delete marker is equal to the size of the key name of the delete marker\. A key name is a sequence of Unicode characters\. The UTF\-8 encoding adds from 1 to 4 bytes of storage to your bucket for each character in the name\. For more information about key names, see [Object Keys](UsingMetadata.md#object-keys)\. For information about deleting a delete marker, see [Removing Delete Markers](RemDelMarker.md)\.  
 


### PR DESCRIPTION
…delete markers

doc should be updated to state for the sake of accuracy that even IAM actors or other AWS accounts that have permission to the bucket can remove delete markers, it's not just limited to the bucket owner.

*Issue #, if available:*
doc says only the bucket owner can remove delete markers which is not true, other AWS accounts and their IAM actors can remove delete markers

*Description of changes:*

adding the 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
