### PR TITLE
Provide more clarity on S3 static website URL

### DIFF
--- a/doc_source/HostingWebsiteOnS3Setup.md
+++ b/doc_source/HostingWebsiteOnS3Setup.md
@@ -67,11 +67,14 @@ You can configure an Amazon S3 bucket to function like a website\. This example 
 
 ## Step 4: Testing Your Website<a name="step4-test-web-site"></a>
 
-Type the following URL in the browser, replacing *example\-bucket* with the name of your bucket and *website\-region* with the name of the AWS Region where you deployed your bucket\. For information about AWS Region names, see [Website Endpoints](WebsiteEndpoints.md) \)\. 
+Type the following URL in the browser, replacing *example\-bucket* with the name of your bucket and *region* with the name of the AWS Region where you deployed your bucket\.
 
 ```
 1. http://example-bucket.s3-website-region.amazonaws.com
 ```
+
+**Note**
+The format of the URL may vary depending on which region you've deployed your bucket in. For information about AWS Region names, see [Website Endpoints](WebsiteEndpoints.md) \)\. 
 
 If your browser displays your `index.html` page, the website was successfully deployed\.
 


### PR DESCRIPTION
The URL format may change based on which region the S3 bucket was created in.

Apologies for what looks like white space changes that Github introduced on line 84.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
