### PR TITLE
Updated CloudFront OAI CanonicalUser

### DIFF
--- a/doc_source/example-bucket-policies.md
+++ b/doc_source/example-bucket-policies.md
@@ -197,7 +197,7 @@ The following example bucket policy grants a CloudFront Origin Identity permissi
  5.      {
  6.        "Sid":" Grant a CloudFront Origin Identity access to support private content",
  7.        "Effect":"Allow",
- 8.        "Principal":{"CanonicalUser":"79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be"},
+ 8.        "Principal":{"CanonicalUser":"79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be4d501a94b759d54c10c75084ae82391e"},
  9.        "Action":"s3:GetObject",
 10.        "Resource":"arn:aws:s3:::example-bucket/*"
 11.      }


### PR DESCRIPTION
Updated "Granting Permission to an Amazon CloudFront Origin Identity" example bucket policy with a more accurate CloudFront CanonicalUser ID.  As the current one was more inline with an AWS account's CanonicalUser ID, instead of a CloudFront's OAI.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
