### PR TITLE
Adding a doc reference for IAM prefix definitions

### DIFF
--- a/doc_source/notification-content-structure.md
+++ b/doc_source/notification-content-structure.md
@@ -113,3 +113,6 @@ The following are example messages:
   38.    ]
   39. }
   ```
+  
+  **Note**  
+You can find a definition of each IAM identification prefix (AIDA, AROA, AGPA, etc) here: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-prefixes \.


### PR DESCRIPTION
A customer requested that they'd like to see us reference the IAM prefix definition list on this page.

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
