### PR TITLE
Updating TCP Window Scaling RFC

### DIFF
--- a/doc_source/TCPWindowScaling.md
+++ b/doc_source/TCPWindowScaling.md
@@ -2,4 +2,4 @@
 
  TCP window scaling allows you to improve network throughput performance between your operating system and application layer and Amazon S3 by supporting window sizes larger than 64 KB\. At the start of the TCP session, a client advertises its supported receive window WSCALE factor, and Amazon S3 responds with its supported receive window WSCALE factor for the upstream direction\. 
 
- Although TCP window scaling can improve performance, it can be challenging to set correctly\. Make sure to adjust settings at both the application and kernel level\. For more information about TCP window scaling, refer to your operating system's documentation and go to [RFC 1323](http://www.ietf.org/rfc/rfc1323.txt)\. 
+ Although TCP window scaling can improve performance, it can be challenging to set correctly\. Make sure to adjust settings at both the application and kernel level\. For more information about TCP window scaling, refer to your operating system's documentation and go to [RFC 7323](https://tools.ietf.org/pdf/rfc7323.pdf)\. 


### PR DESCRIPTION
A simple update to this reference wiki page where the initial RFC (1323) outlined is currently considered obsolete and should be replaced by RFC 7323.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
