### PR TITLE
Fix the replication PolicyForDestinationBucket

### DIFF
--- a/doc_source/setting-repl-config-perm-overview.md
+++ b/doc_source/setting-repl-config-perm-overview.md
@@ -117,7 +117,11 @@ When source and destination buckets aren't owned by the same accounts, the owner
          "Principal":{
             "AWS":"SourceBucket-AcctID"
          },
-         "Action":"s3:List*",
+         "Action":[
+           "s3:List*",
+           "s3:GetBucketVersioning",
+           "s3:PutBucketVersioning"
+         ],
          "Resource":"arn:aws:s3:::destinationbucket"
       }
    ]


### PR DESCRIPTION
*Description of changes:*

I have updated the `PolicyForDestinationBucket`, as there's a gap between the policy that is advised when one configures the replication via console and the policy that is here in the doc.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
