### PR TITLE
Fix access log regexp in athena table definition

### DIFF
--- a/doc_source/using-s3-access-logs-to-identify-requests.md
+++ b/doc_source/using-s3-access-logs-to-identify-requests.md
@@ -160,10 +160,7 @@ It's a best practice to create the database in the same AWS Region as your S3 bu
      ) 
      ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.RegexSerDe'
      WITH SERDEPROPERTIES (
-                  'serialization.format' = '1', 'input.regex' = '([^ ]*) ([^ ]*) 
-                  \\[(.*?)\\] ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) \\\"([^ ]*) ([^ ]*) (- |[^ ]*)
-                  \\\" (-|[0-9]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) (\"[^\"]*\") ([^ ]*)
-                  (?: ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*))?.*$' )
+                  'serialization.format' = '1', 'input.regex' = '([^ ]*) ([^ ]*) \\[(.*?)\\] ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) \\\"([^ ]*) ([^ ]*) (- |[^ ]*)\\\" (-|[0-9]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) (\"[^\"]*\") ([^ ]*)(?: ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*))?.*$' )
          LOCATION 's3://awsexamplebucket-logs/prefix'
    ```
 


### PR DESCRIPTION
The access log format regular expression in the athena `CREATE TABLE` statement is invalid: when fetching the data, results contain records, but all fields are empty.

*Issue #, if available:*

*Description of changes:*

It didn't work due to the multiline formatting - extra spaces made the overall expression invalid.
Fixed by removing line breaks and extra spaces in the regular expression.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
