### PR TITLE
Difference between object locking for concurrency and Object Lock feature

### DIFF
--- a/doc_source/Introduction.md
+++ b/doc_source/Introduction.md
@@ -89,7 +89,7 @@ Amazon S3 achieves high availability by replicating data across multiple servers
 +  A process deletes an existing object and immediately lists keys within its bucket\. Until the deletion is fully propagated, Amazon S3 might list the deleted object\. 
 
 **Note**  
-Amazon S3 does not currently support object locking\. If two PUT requests are simultaneously made to the same key, the request with the latest timestamp wins\. If this is an issue, you will need to build an object\-locking mechanism into your application\.   
+Amazon S3 does not currently support object locking for concurrent updates\. If two PUT requests are simultaneously made to the same key, the request with the latest timestamp wins\. If this is an issue, you will need to build an object\-locking mechanism into your application\. Take note that object locking is different from the Amazon S3 Object Lock feature which allows you to store objects using a write-once-read-many (WORM) model and prevent an object from being deleted or overwritten for a fixed amount of time or indefinitely\.  
 Updates are key\-based\. There is no way to make atomic updates across keys\. For example, you cannot make the update of one key dependent on the update of another key unless you design this functionality into your application\.
 
 Buckets have a similar consistency model, with the same caveats\. For example, if you delete a bucket and immediately list all buckets, Amazon S3 might still appear in the list\.


### PR DESCRIPTION
*Issue #, if available:*


This document says: "Amazon S3 does not currently support object locking" which is quite confusing since there is a feature in Amazon S3 called Object Lock:  https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html

There are two things here:

1. Amazon S3 Object Lock feature
2. Object-locking mechanism


The first one is actually an S3 feature to prevent an object from being deleted or overwritten for a fixed amount of time or indefinitely. This is **NOT** relevant in scenarios where two or more servers are **concurrently** accessing the same object.

Reference:
https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lock.html



For the second one, this relates to the concept where there are two or more servers that concurrently update the same object in an Amazon S3 bucket. An "Object-locking" mechanism is a system that "locks" the very first update request to the S3 object and blocks any concurrent update requests to the same object.



*Description of changes:*

I have added some additional information to avoid this kind of ambiguity in the documentation.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
