### PR TITLE
Fix deleted-bucket-eventual-consistency example

### DIFF
--- a/doc_source/Introduction.md
+++ b/doc_source/Introduction.md
@@ -92,7 +92,7 @@ Amazon S3 achieves high availability by replicating data across multiple servers
 Amazon S3 does not currently support object locking\. If two PUT requests are simultaneously made to the same key, the request with the latest timestamp wins\. If this is an issue, you will need to build an object\-locking mechanism into your application\.   
 Updates are key\-based\. There is no way to make atomic updates across keys\. For example, you cannot make the update of one key dependent on the update of another key unless you design this functionality into your application\.
 
-Buckets have a similar consistency model, with the same caveats\. For example, if you delete a bucket and immediately list all buckets, Amazon S3 might still appear in the list\.
+Buckets have a similar consistency model, with the same caveats\. For example, if you delete a bucket and immediately list all buckets, the deleted bucket might still appear in the list\.
 
 The following table describes the characteristics of an eventually consistent read and a consistent read\.
 


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
Introduced in 29f1ee6, the example stated that, immediately after deleting a bucket and listing all,
> Amazon S3 might still appear in the list.

While the just-deleted bucket *might* still appear in the list,
Amazon S3, as a concept, shouldn't.

I made the change in the GitHub web editor, changing only [l. 95](https://github.com/bobmazanec/amazon-s3-developer-guide/commit/c0469096609f3e0b1dad0cfc3510b2a7c68ce2d0#diff-40773b8b6f6d7aa0a4f648198473feb9R95); AFAIK I didn't touch the EOF 🤷

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.