### PR TITLE
Fix incorrect REST Authentication HMAC-SHA1 signatures

### DIFF
--- a/doc_source/RESTAuthentication.md
+++ b/doc_source/RESTAuthentication.md
@@ -31,7 +31,7 @@ This topic explains authenticating requests using Signature Version 2\. Amazon S
 2. Host: awsexamplebucket.s3.us-west-1.amazonaws.com
 3. Date: Mon, 26 Mar 2007 19:37:58 +0000
 4. 
-5. Authorization: AWS AKIAIOSFODNN7EXAMPLE:frJIUN8DYpKDtOLCwo//yllqDzg=
+5. Authorization: AWS AKIAIOSFODNN7EXAMPLE:0j1Rtb0XmlMMHl45zcQlFXrL/jQ=
 ```
 
 ## Using Temporary Security Credentials<a name="UsingTemporarySecurityCredentials"></a>
@@ -147,7 +147,7 @@ This example gets an object from the awsexamplebucket bucket\.
 
 | Request | StringToSign | 
 | --- | --- | 
-|  <pre>GET /photos/puppy.jpg HTTP/1.1<br />Host: awsexamplebucket.us-west-1.s3.amazonaws.com<br />Date: Tue, 27 Mar 2007 19:36:42 +0000<br /><br />Authorization: AWS AKIAIOSFODNN7EXAMPLE:<br />bWq2s1WEIj+Ydj0vQ697zp+IXMU=</pre>  |  <pre>GET\n<br />\n<br />\n<br />Tue, 27 Mar 2007 19:36:42 +0000\n<br />/awsexamplebucket/photos/puppy.jpg</pre>  | 
+|  <pre>GET /photos/puppy.jpg HTTP/1.1<br />Host: awsexamplebucket.us-west-1.s3.amazonaws.com<br />Date: Tue, 27 Mar 2007 19:36:42 +0000<br /><br />Authorization: AWS AKIAIOSFODNN7EXAMPLE:<br />m7eWZVTX0vHEGbqzArfGm9XBFKQ=</pre>  |  <pre>GET\n<br />\n<br />\n<br />Tue, 27 Mar 2007 19:36:42 +0000\n<br />/awsexamplebucket/photos/puppy.jpg</pre>  | 
 
  Note that the CanonicalizedResource includes the bucket name, but the HTTP Request\-URI does not\. \(The bucket is specified by the Host header\.\) 
 
@@ -158,7 +158,7 @@ This example puts an object into the awsexamplebucket bucket\.
 
 | Request | StringToSign | 
 | --- | --- | 
-|  <pre>PUT /photos/puppy.jpg HTTP/1.1<br />Content-Type: image/jpeg<br />Content-Length: 94328<br />Host: awsexamplebucket.s3.us-west-1.amazonaws.com<br />Date: Tue, 27 Mar 2007 21:15:45 +0000<br /><br />Authorization: AWS AKIAIOSFODNN7EXAMPLE:<br />MyyxeRY7whkBe+bq8fHCL/2kKUg=<br /></pre>  |  <pre>PUT\n<br />\n<br />image/jpeg\n<br />Tue, 27 Mar 2007 21:15:45 +0000\n<br />/awsexamplebucket/photos/puppy.jpg</pre>  | 
+|  <pre>PUT /photos/puppy.jpg HTTP/1.1<br />Content-Type: image/jpeg<br />Content-Length: 94328<br />Host: awsexamplebucket.s3.us-west-1.amazonaws.com<br />Date: Tue, 27 Mar 2007 21:15:45 +0000<br /><br />Authorization: AWS AKIAIOSFODNN7EXAMPLE:<br />8ePoXUqVvGs8uP0+D3tYfT8nP8E=<br /></pre>  |  <pre>PUT\n<br />\n<br />image/jpeg\n<br />Tue, 27 Mar 2007 21:15:45 +0000\n<br />/awsexamplebucket/photos/puppy.jpg</pre>  | 
 
  Note the Content\-Type header in the request and in the StringToSign\. Also note that the Content\-MD5 is left blank in the StringToSign, because it is not present in the request\. 
 
@@ -169,7 +169,7 @@ This example lists the content of the awsexamplebucket bucket\.
 
 | Request | StringToSign | 
 | --- | --- | 
-|  <pre>GET /?prefix=photos&max-keys=50&marker=puppy HTTP/1.1<br />User-Agent: Mozilla/5.0<br />Host: awsexamplebucket.s3.us-west-1.amazonaws.com<br />Date: Tue, 27 Mar 2007 19:42:41 +0000<br /><br />Authorization: AWS AKIAIOSFODNN7EXAMPLE:<br />htDYFYduRNen8P9ZfE/s9SuKy0U=</pre>  |  <pre>GET\n<br />\n<br />\n<br />Tue, 27 Mar 2007 19:42:41 +0000\n<br />/awsexamplebucket/</pre>  | 
+|  <pre>GET /?prefix=photos&max-keys=50&marker=puppy HTTP/1.1<br />User-Agent: Mozilla/5.0<br />Host: awsexamplebucket.s3.us-west-1.amazonaws.com<br />Date: Tue, 27 Mar 2007 19:42:41 +0000<br /><br />Authorization: AWS AKIAIOSFODNN7EXAMPLE:<br />oiKhrIGulXPQPYu8IgY2hiaJTPo=</pre>  |  <pre>GET\n<br />\n<br />\n<br />Tue, 27 Mar 2007 19:42:41 +0000\n<br />/awsexamplebucket/</pre>  | 
 
  Note the trailing slash on the CanonicalizedResource and the absence of query string parameters\. 
 
@@ -180,7 +180,7 @@ This example fetches the access control policy subresource for the 'awsexamplebu
 
 | Request | StringToSign | 
 | --- | --- | 
-|  <pre>GET /?acl HTTP/1.1<br />Host: awsexamplebucket.s3.us-west-1.amazonaws.com<br />Date: Tue, 27 Mar 2007 19:44:46 +0000<br /><br />Authorization: AWS AKIAIOSFODNN7EXAMPLE:<br />c2WLPFtWHVgbEmeEG93a4cG37dM=</pre>  |  <pre>GET\n<br />\n<br />\n<br />Tue, 27 Mar 2007 19:44:46 +0000\n<br />/awsexamplebucket/?acl</pre>  | 
+|  <pre>GET /?acl HTTP/1.1<br />Host: awsexamplebucket.s3.us-west-1.amazonaws.com<br />Date: Tue, 27 Mar 2007 19:44:46 +0000<br /><br />Authorization: AWS AKIAIOSFODNN7EXAMPLE:<br />W6dj+8Fz8Ub8y3RJHi6m7P7HHkw=</pre>  |  <pre>GET\n<br />\n<br />\n<br />Tue, 27 Mar 2007 19:44:46 +0000\n<br />/awsexamplebucket/?acl</pre>  | 
 
  Notice how the subresource query string parameter is included in the CanonicalizedResource\. 
 
@@ -191,7 +191,7 @@ This example deletes an object from the 'awsexamplebucket' bucket using the path
 
 | Request | StringToSign | 
 | --- | --- | 
-|  <pre>DELETE /awsexamplebucket/photos/puppy.jpg HTTP/1.1<br />User-Agent: dotnet<br />Host: s3.us-west-1.amazonaws.com<br />Date: Tue, 27 Mar 2007 21:20:27 +0000<br /><br />x-amz-date: Tue, 27 Mar 2007 21:20:26 +0000<br />Authorization: AWS AKIAIOSFODNN7EXAMPLE:lx3byBScXR6KzyMaifNkardMwNk=</pre>  |  <pre>DELETE\n<br />\n<br />\n<br />Tue, 27 Mar 2007 21:20:26 +0000\n<br />/awsexamplebucket/photos/puppy.jpg</pre>  | 
+|  <pre>DELETE /awsexamplebucket/photos/puppy.jpg HTTP/1.1<br />User-Agent: dotnet<br />Host: s3.us-west-1.amazonaws.com<br />Date: Tue, 27 Mar 2007 21:20:27 +0000<br /><br />x-amz-date: Tue, 27 Mar 2007 21:20:26 +0000<br />Authorization: AWS AKIAIOSFODNN7EXAMPLE:hYT2WLqRzKo3LA+VwIiU5NmV5pg=</pre>  |  <pre>DELETE\n<br />\n<br />\n<br />Tue, 27 Mar 2007 21:20:26 +0000\n<br />/awsexamplebucket/photos/puppy.jpg</pre>  | 
 
  Note how we used the alternate 'x\-amz\-date' method of specifying the date \(because our client library prevented us from setting the date, say\)\. In this case, the `x-amz-date` takes precedence over the `Date` header\. Therefore, date entry in the signature must contain the value of the `x-amz-date` header\. 
 
@@ -202,7 +202,7 @@ This example uploads an object to a CNAME style virtual hosted bucket with metad
 
 | Request | StringToSign | 
 | --- | --- | 
-|  <pre>PUT /db-backup.dat.gz HTTP/1.1<br />User-Agent: curl/7.15.5<br />Host: static.awsexamplebucket.net:8080<br />Date: Tue, 27 Mar 2007 21:06:08 +0000<br /><br />x-amz-acl: public-read<br />content-type: application/x-download<br />Content-MD5: 4gJE4saaMU4BqNR0kLY+lw==<br />X-Amz-Meta-ReviewedBy: joe@awsexamplebucket.net<br />X-Amz-Meta-ReviewedBy: jane@awsexamplebucket.net<br />X-Amz-Meta-FileChecksum: 0x02661779<br />X-Amz-Meta-ChecksumAlgorithm: crc32<br />Content-Disposition: attachment; filename=database.dat<br />Content-Encoding: gzip<br />Content-Length: 5913339<br /><br />Authorization: AWS AKIAIOSFODNN7EXAMPLE:<br />ilyl83RwaSoYIEdixDQcA4OnAnc=</pre>  |  <pre>PUT\n<br />4gJE4saaMU4BqNR0kLY+lw==\n<br />application/x-download\n<br />Tue, 27 Mar 2007 21:06:08 +0000\n<br /><br />x-amz-acl:public-read\n<br />x-amz-meta-checksumalgorithm:crc32\n<br />x-amz-meta-filechecksum:0x02661779\n<br />x-amz-meta-reviewedby:<br />joe@awsexamplebucket.net,jane@awsexamplebucket.net\n<br />/static.awsexamplebucket.net/db-backup.dat.gz</pre>  | 
+|  <pre>PUT /db-backup.dat.gz HTTP/1.1<br />User-Agent: curl/7.15.5<br />Host: static.awsexamplebucket.net:8080<br />Date: Tue, 27 Mar 2007 21:06:08 +0000<br /><br />x-amz-acl: public-read<br />content-type: application/x-download<br />Content-MD5: 4gJE4saaMU4BqNR0kLY+lw==<br />X-Amz-Meta-ReviewedBy: joe@awsexamplebucket.net<br />X-Amz-Meta-ReviewedBy: jane@awsexamplebucket.net<br />X-Amz-Meta-FileChecksum: 0x02661779<br />X-Amz-Meta-ChecksumAlgorithm: crc32<br />Content-Disposition: attachment; filename=database.dat<br />Content-Encoding: gzip<br />Content-Length: 5913339<br /><br />Authorization: AWS AKIAIOSFODNN7EXAMPLE:<br />YYFW96VW83RHsd/5I1R57NPaL8I=</pre>  |  <pre>PUT\n<br />4gJE4saaMU4BqNR0kLY+lw==\n<br />application/x-download\n<br />Tue, 27 Mar 2007 21:06:08 +0000\n<br /><br />x-amz-acl:public-read\n<br />x-amz-meta-checksumalgorithm:crc32\n<br />x-amz-meta-filechecksum:0x02661779\n<br />x-amz-meta-reviewedby:<br />joe@awsexamplebucket.net,jane@awsexamplebucket.net\n<br />/static.awsexamplebucket.net/db-backup.dat.gz</pre>  | 
 
  Notice how the 'x\-amz\-' headers are sorted, trimmed of whitespace, and converted to lowercase\. Note also that multiple headers with the same name have been joined using commas to separate values\. 
 


### PR DESCRIPTION
These were broken in 59f39a7d26d8bb6205d2ae36e15792d1cb74c630 when the example bucket name was renamed from `johnsmith` to `awsexamplebucket`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.