### PR TITLE
fix: Support log lines with type S3.EXPIRE.OBJECT

### DIFF
--- a/doc_source/using-s3-access-logs-to-identify-requests.md
+++ b/doc_source/using-s3-access-logs-to-identify-requests.md
@@ -161,7 +161,7 @@ It's a best practice to create the database in the same AWS Region as your S3 bu
      ROW FORMAT SERDE 'org.apache.hadoop.hive.serde2.RegexSerDe'
      WITH SERDEPROPERTIES (
                   'serialization.format' = '1', 'input.regex' = '([^ ]*) ([^ ]*) 
-                  \\[(.*?)\\] ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) \\\"([^ ]*) ([^ ]*) (- |[^ ]*)
+                  \\[(.*?)\\] ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) \\\"([^ ]* |)([^ ]* |)([^\\\"]*)
                   \\\" (-|[0-9]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) (\"[^\"]*\") ([^ ]*)
                   (?: ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*) ([^ ]*))?.*$' )
          LOCATION 's3://awsexamplebucket1-logs/prefix'


### PR DESCRIPTION
*Description of changes:*

The proposed regexp does not cover one case: `Operation=S3.EXPIRE.OBJECT` then some fields are empty and lines are skipped in results.

The proposed version of regexp supports all types of operations.

Example line with `Operation=S3.EXPIRE.OBJECT`:

```
abc123 bucket-name [22/May/2020:01:36:31 +0000] - AmazonS3 72F632309CC50F1D S3.EXPIRE.OBJECT file.zip "-" - - - 440561 - - "-" "-" - JKffSS5PIDjVhXt/BUIsvlbzznhYf6EVers
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
