### PR TITLE
Update s3-glacier-select-sql-reference-operators.md

### DIFF
--- a/doc_source/s3-glacier-select-sql-reference-operators.md
+++ b/doc_source/s3-glacier-select-sql-reference-operators.md
@@ -33,6 +33,7 @@ Addition, subtraction, multiplication, division, and modulo are supported\.
 + \+
 + \-
 + \*
++ /
 + %
 
 ## Operator Precedence<a name="s3-glacier-select-sql-reference-op-Precedence"></a>


### PR DESCRIPTION
Adding missing divide "/" under Math operators
