### PR TITLE
FIX: Alternative CNAMEs are necessary for custom domains

### DIFF
--- a/doc_source/website-hosting-cloudfront-walkthrough.md
+++ b/doc_source/website-hosting-cloudfront-walkthrough.md
@@ -33,7 +33,8 @@ First, you create a CloudFront distribution\. This makes your website available 
 
    1. Leave **Price Class** set to **Use All Edge Locations \(Best Performance\)**\.
 
-   1. Keep **Alternate Domain Names \(CNAMEs\)** blank\.
+   1. Enter the domain names you want to use (names of your buckets) into the field for **Alternate Domain Names \(CNAMEs\)**\.
+      You will also need to set a custom SSL certificate that covers these CNAMEs.
 
    1. In **Default Root Object**, enter the name of your index document, for example, `index.html`\. 
 


### PR DESCRIPTION
Route 53 cannot point to Cloudfront unless alternative CNAMEs are added to the distribution. This in turn requires a custom SSL certificate.

## References 
- https://aws.amazon.com/premiumsupport/knowledge-center/route-53-no-targets/
- https://tej-pochiraju.gitbook.io/how-tos/

*Issue #, if available:*

*Description of changes:*

Modified documentation to suggest that the user needs to add alternative CNAMEs and enable a custom SSL certificate.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
