### PR TITLE
Change AWS console link to IAM link

### DIFF
--- a/doc_source/walkthrough1.md
+++ b/doc_source/walkthrough1.md
@@ -301,7 +301,7 @@ When you choose a bucket on the Amazon S3 console, the console first sends the [
 
 **To enable users to list root\-level bucket content**
 
-1. Sign in to the AWS Management Console and open the Amazon S3 console at [https://console\.aws\.amazon\.com/s3/](https://console.aws.amazon.com/s3/)\.
+1. Sign in to the AWS Management Console and open the IAM console at [https://console\.aws\.amazon\.com/iam/](https://console.aws.amazon.com/iam/)\.
 
    Use your AWS account credentials, not the credentials of an IAM user, to sign in to the console\.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Step 4.2, in the **To enable users to list root-level bucket** content section, has users open the S3 console, but this should point to the IAM console instead, since the section involves policy management. I changed the link from https://console.aws.amazon.com/s3/ to https://console.aws.amazon.com/iam/.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
