### PR TITLE
add additional clarity on encryption for cross-account operations

### DIFF
--- a/doc_source/bucket-encryption.md
+++ b/doc_source/bucket-encryption.md
@@ -36,6 +36,8 @@ Amazon S3 buckets with default bucket encryption using SSE\-KMS cannot be used a
 
 Be aware of the following when using encryption for cross\-account operations:
 + The aws/s3 AWS managed CMK is used when a CMK ARN or alias is not provided at request\-time, nor via the bucket's default encryption configuration\.
++ The aws/s3 CMK should be used if you're uploading or accessing S3 objects using AWS Identity and Access Management (IAM) principals that are in the same AWS account as the CMK.
++ Use a custom CMK if you want to grant cross-account access to your S3 objects. You can configure the policy of a custom CMK to allow access from another account.
 + If specifying your own CMK, you should use a fully qualified CMK key ARN\. When using a CMK alias, be aware that KMS will resolve the key within the requester’s account\. This may result in data encrypted with a CMK that belongs to the requester, and not the bucket administrator\.
 + You must specify a key that you \(the requester\) has been granted `Encrypt` permission to\. For more information, see [Allows Key Users to Use a CMK for Cryptographic Operations](https://docs.aws.amazon.com/kms/latest/developerguide/key-policies.html#key-policy-users-crypto)\.
 


### PR DESCRIPTION
*Issue #, if available: N/A

*Description of changes: add additional clarity on encryption for cross-account operations

Info pulled from the following support article - https://aws.amazon.com/premiumsupport/knowledge-center/s3-object-encrpytion-keys/


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
