### PR TITLE
s3 prefix for Bucket Policy when StringNotEquals

### DIFF
--- a/doc_source/amazon-s3-policy-keys.md
+++ b/doc_source/amazon-s3-policy-keys.md
@@ -514,7 +514,7 @@ If you add the `Principal` element to the above user policy, identifying the use
          "Resource": "arn:aws:s3:::awsexamplebucket1",
          "Condition" : {
              "StringNotEquals" : {
-                 "s3:prefix": "examplefolder" 
+                 "s3:prefix": "projects" 
              }
           } 
        }         


### PR DESCRIPTION
This is supposed to be 'projects' and not 'examplefolder' as the Policy is supposed to be denying permission to all other prefixes with an exception of prefix 'projects'.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
