### PR TITLE
Add versioning requirement to replication.

### DIFF
--- a/doc_source/replication-troubleshoot.md
+++ b/doc_source/replication-troubleshoot.md
@@ -30,7 +30,7 @@ If object replicas don't appear in the destination bucket after you configure re
   2.            "s3:ReplicateDelete",
   3.            "s3:ReplicateTags"
   ```
-+ Versioning has not been suspended on either bucket. Both source and destination buckets must have versioning enabled.
++ Verify that versioning has not been suspended on either bucket. Both source and destination buckets must have versioning enabled.
 
 ## Related topics<a name="replication-troubleshoot-related-topics"></a>
 

--- a/doc_source/replication-troubleshoot.md
+++ b/doc_source/replication-troubleshoot.md
@@ -30,6 +30,7 @@ If object replicas don't appear in the destination bucket after you configure re
   2.            "s3:ReplicateDelete",
   3.            "s3:ReplicateTags"
   ```
++ Versioning has not been suspended on either bucket. Both source and destination buckets must have versioning enabled.
 
 ## Related topics<a name="replication-troubleshoot-related-topics"></a>
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Updates the S3 replication troubleshooting page to include that versioning must be (and remain) enabled on both buckets. 

[Both source and destination buckets must have versioning enabled.](https://docs.aws.amazon.com/AmazonS3/latest/dev/replication.html)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
