### PR TITLE
Fix CLI examples for s3control API

### DIFF
--- a/doc_source/batch-ops-examples-cli.md
+++ b/doc_source/batch-ops-examples-cli.md
@@ -570,7 +570,7 @@ read -d '' OPERATION <<EOF
 {
   "S3PutObjectRetention": {
     "Retention": {
-      "RetainUntilDate":"Jan 30 00:00:00 PDT 2020",
+      "RetainUntilDate":"2020-01-30T00:00:00",
       "Mode":"GOVERNANCE"
     }
   }

--- a/doc_source/batch-ops-examples-cli.md
+++ b/doc_source/batch-ops-examples-cli.md
@@ -469,7 +469,7 @@ read -d '' MANIFEST <<EOF
     ]
   },
   "Location": {
-    "ObjectArn": "arn:aws:s3:::ManifestBucket/complaince-objects-manifest.csv",
+    "ObjectArn": "arn:aws:s3:::ManifestBucket/compliance-objects-manifest.csv",
     "ETag": "Your-manifest-ETag"
   }
 }


### PR DESCRIPTION
*Description of changes:*

Two updates for https://docs.aws.amazon.com/AmazonS3/latest/dev/batch-ops-examples-cli.html:
- fix a typo (<tt><i>complaince</i>-objects-manifest.csv</tt>)
- use ISO 8601 date format in the example invocation; readers might not recognize what PDT means here

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
